### PR TITLE
fix: fix setExpression won't update after resetExpression

### DIFF
--- a/src/cubism-common/ExpressionManager.ts
+++ b/src/cubism-common/ExpressionManager.ts
@@ -146,6 +146,7 @@ export abstract class ExpressionManager<
      */
     resetExpression(): void {
         this._setExpression(this.defaultExpression);
+        this.currentExpression = this.defaultExpression;
     }
 
     /**


### PR DESCRIPTION
Reproduction Path
```js
model.setExpression('test');
model.resetExpression();

model.setExpression('test'); // this won't update actual expression
```
cause reason

![image](https://github.com/user-attachments/assets/15d90cb6-91e4-4923-b64e-4b1082b9b43b)
